### PR TITLE
Acknowledge

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,10 +276,10 @@ subscribeParams: #parameters for subscribing to an event
   subscriberId: rebelArmy
   initialPosition: latest
   parallelism: 1
-  acks: [] # if the acks are present in client: type: test, then the subscriber will be storing acknowledgement in this field
   client:
     type: test
     data: ['obi-wan'] # test subscriber may include test data to run without a producer 
+    acks: [] # if the acks are present in client: type: test, then the subscriber will be storing acknowledgement in this field
 ```
 
 ## Dispatcher mode
@@ -301,6 +301,12 @@ acknowledgement in the template. HTTP client blocks the synchronous HTTP respons
 ### Test Client Durability
 To develop and test workflows with the test client adding `acks` field will enable test acknowledgements in the client. Messages processed by 
 the workflow will be added to the `acks` array.
+```
+  client:
+    type: test
+    data: ['obi-wan'] # test subscriber may include test data to run without a producer 
+    acks: [] # if the acks are present in client: type: test, then the subscriber will be storing acknowledgement in this field
+```
 
 ### Pulsar Client Durability
 Pulsar pub/sub relies on server side acknowledgement, similar to the test data. On failure or restart, the subscriber 

--- a/README.md
+++ b/README.md
@@ -10,13 +10,16 @@
   * [Concurrent, Event Driven, Non-blocking](#concurrent-event-driven-non-blocking)
   * [Atomic State Updates](#atomic-state-updates)
   * [Pure Function Pipelines - $serial and $parallel](#pure-function-pipelines---serial-and-parallel)
+* [Pub/Sub Clients Configuration](#pubsub-clients-configuration)
+  * [Test Data](#test-data)
+  * [Dispatcher mode](#dispatcher-mode)
 * [Durability](#durability)
   * [Pub/Sub durability models](#pubsub-durability-models)
-    * [Test Data](#test-data-)
-  * [Pulsar](#pulsar)
-  * [Kafka](#kafka)
+    * [Test Client Durability](#test-client-durability)
+    * [Pulsar Client Durability](#pulsar-client-durability)
+    * [Kafka Client Durability](#kafka-client-durability)
   * [Workflow Step Logs](#workflow-step-logs)
-  * [snapshots](#snapshots)
+  * [Workflow snapshots](#workflow-snapshots)
 * [retries](#retries)
 * [Workflow APIs](#workflow-apis)
 <!-- TOC -->
@@ -127,9 +130,9 @@ start: ${ (produceParams.data; $millis()) } #record start time, after test datas
 # producer will be sending some test data
 produceParams:
   type: "my-topic"
-  data: ${['luke', 'han', 'leia', 'R2-D2', 'Owen', 'Biggs', 'Obi-Wan', 'Anakin', 'Chewbacca', 'Wedge'].('https://swapi.tech/api/people/?search='&$)}
   client:
     type: test
+    data: ${['luke', 'han', 'leia', 'R2-D2', 'Owen', 'Biggs', 'Obi-Wan', 'Anakin', 'Chewbacca', 'Wedge'].('https://swapi.tech/api/people/?search='&$)}
 # the subscriber's 'to' function will be called on each received event
 subscribeParams: #parameters for subscribing to an event
   source: cloudEvent
@@ -223,7 +226,7 @@ array and append $rebel to it, in order to illustrate the dangers of the well-kn
 joinResistance:  |
   /${ 
     function($url){(
-        $rebel := $fetch($url).json().results[0].name; 
+        $rebel := $fetch($url).json().results[0].name;
         $set( "/rebelForces", $rebelForces~>$append($rebel)) /* BUG!! */
     )}  
   }
@@ -251,33 +254,21 @@ function($x){ $x ~> f1 ~> f2 ~> f3 ~> function($x){$set('/saveResult/-', $x) } }
 ```
 This pipeline can be concurrently dispatched safely. 
 
-# Durability
-Stated Workflows provides a `$serial` and a `$parallel` function that should be used when you want to run continuous 
-workflow with data coming from a HTTP or cloudEvent sources. Each workflow invocation input and step processing logs are 
-persisted in the template in the beginning of step invocation and in the end. When the workflow is finished, the logs 
-are removed. Periodic snapshots include TemplateProcessor template, output and options, and can be used to recover 
-workflow processing from the last snapshotted state. 
+# Pub/Sub Clients Configuration
+Stated Workflow comes with built-in HTTP, Pulsar, Kafka, Dispatcher and Test clients for cloudEvent subscribe command. Each client
+implements its own durability model.
 
-StatedREPL `restore` command can be used to recover the template execution from a snapshot. 
-
-## Pub/Sub durability models
-Stated Workflow comes with built-in HTTP, Pulsar, Kafka and Test clients for cloudEvent subscribe command. Each client 
-implements its own durability model. 
-
-Pulsar and Kafka use server side acknowledgement to ensure that the message is not lost. Test client uses a simple 
-acknowledgement in the template. HTTP client blocks the synchronous HTTP response until the first step persist.
- 
-### Test Data 
-Test publisher and subscriber can be used to develop and test workflows. Test publisher may include a `data` type to 
-send it directly to test subscriber dispatcher with acknowledgement in the template. 
+## Test Data
+Test clients for publisher and subscriber can be used to develop and test workflows. Test publisher may include `testData` array of data 
+to send it directly to test subscriber dispatcher with acknowledgement in the template.
 
 Example snippets from `example/joinResistanceRecovery.yaml` template.
 ```yaml
 produceParams:
   type: "rebelDispatch"
-  data: ['luke', 'han', 'leia']
   client:
     type: test # test client produces directly to the test subscriber dispatcher
+    testData: ['luke', 'han', 'leia'] # test producer only makes sense when it includes test data
 subscribeParams: #parameters for subscribing to an event
   source: cloudEvent
   type: /${ produceParams.type } # subscribe to the same topic as we are publishing to test events
@@ -288,16 +279,38 @@ subscribeParams: #parameters for subscribing to an event
   acks: [] # if the acks are present in client: type: test, then the subscriber will be storing acknowledgement in this field
   client:
     type: test
+    data: ['obi-wan'] # test subscriber may include test data to run without a producer 
 ```
-## Pulsar
+
+## Dispatcher mode
+When subscriber client type is set to `dispatcher` or `test`, it will be running the workflow and expecting an external process to add data. 
+
+# Durability
+Stated Workflows provides a `$serial` and a `$parallel` function that should be used when you want to run continuous 
+workflow with data coming from a HTTP or cloudEvent sources. Each workflow invocation input and step processing logs are 
+persisted in the template in the beginning of step invocation and in the end. When the workflow is finished, the logs 
+are removed. Periodic snapshots include TemplateProcessor template, output and options, and can be used to recover 
+workflow processing from the last snapshotted state. 
+
+StatedREPL `restore` command can be used to recover the template execution from a snapshot. 
+
+## Pub/Sub durability models
+Pub/Sub clients implement its own durability model. Pulsar and Kafka use server side acknowledgement to ensure that the message is not lost. Test client uses a simple 
+acknowledgement in the template. HTTP client blocks the synchronous HTTP response until the first step persist.
+
+### Test Client Durability
+To develop and test workflows with the test client adding `acks` field will enable test acknowledgements in the client. Messages processed by 
+the workflow will be added to the `acks` array.
+
+### Pulsar Client Durability
 Pulsar pub/sub relies on server side acknowledgement, similar to the test data. On failure or restart, the subscriber 
 will continue from the next unacknowledged message, and will skip steps already completed in the restored workflow 
 snapshot.
 
-## Kafka
+### Kafka Client Durability
 Kafka can rely on the consumer group commited offset. For parallelism greater than 1, the subscriber will be storing 
 all unacknowledged messages and calculating the lowest offset to be commited. A combination of snapshotted stated and 
-kafka server side consumer offset helps to minimize double-processing of already processed steps. 
+kafka server side consumer offset helps to minimize double-processing of already processed steps.
 
 ## Workflow Step Logs
 The `$serial` and `$parallel` functions accept an array of object called "steps". A step is nothing but an object with
@@ -338,7 +351,7 @@ The id is used as a log key. The logs are stored inside each step.
   }
 }
 ```
-When the step completes, its invocation log is removed. 
+When a step completes, its invocation log is removed. 
 ```json
 {
   "out": "${ $serial([f1, f2])}",
@@ -355,7 +368,7 @@ When the step completes, its invocation log is removed.
 The `$serial` and `$parallel` functions understand the logs. When a template is restored from a snapshot, `$serial` and 
 `$parallel` use these logs to skip completed steps and resume their work at the last incomplete step in every invocation log.
 
-## snapshots
+## Workflow snapshots
 Snapshots save the state of a stated template, repeatedly as it runs. Snapshotting allows a Stated Workflow to be stopped
 non-gracefully, and restored from the snapshot. The step logs allow invocations to restart where they left off.  
 

--- a/example/backpressure.yaml
+++ b/example/backpressure.yaml
@@ -1,9 +1,9 @@
 # producer will be sending some test data
 produceParams:
   type: "my-topic"
-  data: ${[1..10].('bleep_' & $string($))}
   client:
     type: test
+    data: ${[1..10].('bleep_' & $string($))}
 # the subscriber's 'to' function will be called on each received event
 slowSubscribeParams: #parameters for subscribing to an event
   source: cloudEvent

--- a/example/correlate.yaml
+++ b/example/correlate.yaml
@@ -15,14 +15,14 @@ listenForResponse:
   initialPosition: latest
 command:
   type: 'my-topic'
-  data: [{type: 'DO_IT', correlationId: "${ $floor($random()*100000) }" }]
   client:
     type: test
+    data: [{type: 'DO_IT', correlationId: "${ $floor($random()*100000) }" }]
 resp:
   type: 'my-topic'
-  data: [{type: 'DONE_IT', correlationId: 'set me'}]
   client:
     type: test
+    data: [{type: 'DONE_IT', correlationId: 'set me'}]
 listenForCommand:
   source: cloudEvent
   type: 'my-topic'

--- a/example/dumpster/changePersistence.yaml
+++ b/example/dumpster/changePersistence.yaml
@@ -1,9 +1,9 @@
 # producer will be sending some test data
 produceParams:
   type: "my-topic"
-  data: ['luke', 'han', 'leia']
   client:
     type: test
+    data: ['luke', 'han', 'leia']
 # the subscriber's 'to' function will be called on each received event
 subscribeParams: #parameters for subscribing to an event
   source: cloudEvent

--- a/example/dumpster/pubsub-kafka.yaml
+++ b/example/dumpster/pubsub-kafka.yaml
@@ -1,14 +1,14 @@
 # Droid R2-D2 is sending messages to the Rebel Alliance's communication channel
 produceParams:
   type: "rebel-comm-channel"
-  data: |
-    ${ 
-      function(){  
-        {'message': 'Rebel Fleet Coordinates', 'location': $random()} 
-      } 
-    }
   client:
     type: pulsar
+    data: |
+      ${ 
+        function(){  
+          {'message': 'Rebel Fleet Coordinates', 'location': $random()} 
+        } 
+      }
 # Droid C-3PO will intercept and log each received message for the Rebel Alliance
 subscribeParams: #parameters for subscribing to a holocomm transmission
   source: cloudEvent

--- a/example/dumpster/pubsub-pulsar-backup.yaml
+++ b/example/dumpster/pubsub-pulsar-backup.yaml
@@ -1,9 +1,9 @@
 # producer will be sending some test data
 produceParams:
   type: "my-topic"
-  data: ['luke', 'han', 'leia']
   client:
     type: pulsar
+    data: ['luke', 'han', 'leia']
 # the subscriber's 'to' function will be called on each received event
 subscribeParams: #parameters for subscribing to an event
   source: cloudEvent

--- a/example/dumpster/test.yaml
+++ b/example/dumpster/test.yaml
@@ -1,7 +1,6 @@
 start$: $subscribe(subscribeParams)
 name: nozzleWork
 subscribeParams: #parameters for subscribing to a cloud event
-  testData: "${  [1..10000].({'name': 'nozzleTime', 'order':$})  }"
   type: sys:cron
   filter$: function($e){ $e.name='nozzleTime' }
   to: ../${myWorkflow$}
@@ -9,6 +8,7 @@ subscribeParams: #parameters for subscribing to a cloud event
   source: cloudEvent
   client:
     type: test
+    testData: "${  [1..10000].({'name': 'nozzleTime', 'order':$})  }"
 
 myWorkflow$: |
   function($e){

--- a/example/dumpster/wf-all.yaml
+++ b/example/dumpster/wf-all.yaml
@@ -2,12 +2,14 @@ start$: $subscribe(subscribeParams, {})
 name: nozzleWork
 subscribeParams: #parameters for subscribing to a cloud event
   source: cloudEvent
-  testData: "${  [1].([{'name': 'nozzleTime', 'order':$}])  }"
   type: 'my-topic'
   filter$: function($e){ $e.name='nozzleTime' }
   to: ../${myWorkflow$}
   parallelism: 2
   subscriberId: ../${name}
+  client:
+    type: test
+    testData: "${  [1].([{'name': 'nozzleTime', 'order':$}])  }"
 myWorkflow$: |
   function($e){
       $e ~> $serial([step1, step2])

--- a/example/dumpster/wf-continuous.yaml
+++ b/example/dumpster/wf-continuous.yaml
@@ -2,12 +2,14 @@ start$: $subscribe(subscribeParams, {})
 name: nozzleWork
 subscribeParams: #parameters for subscribing to a cloud event
   source: cloudEvent
-  testData: "${  [1].([{'name': 'nozzleTime', 'order':$}])  }"
   type: 'my-topic'
   filter$: function($e){ $e.name='nozzleTime' }
   to: ../${myWorkflow$}
   parallelism: 2
   subscriberId: ../${name}
+  client:
+    type: test
+    testData: "${  [1].([{'name': 'nozzleTime', 'order':$}])  }"
 myWorkflow$: |
   function($e){
       $e ~> $serial([step1, step2])

--- a/example/dumpster/wf-wip.yaml
+++ b/example/dumpster/wf-wip.yaml
@@ -3,20 +3,24 @@ start2$: "$recover(subscribeParams2) ~> $subscribe(subscribeParams2, {})"
 name: nozzleWork
 subscribeParams1: #parameters for subscribing to a cloud event
   source: cloudEvent
-  testData: "${  [1].([{'name': 'nozzleTime1', 'order':$}])  }"
   type: 'my-topic'
   filter$: function($e){ $e.name='nozzleTime' }
   to: ../${myWorkflow1$}
   parallelism: 2
   subscriberId: ../${name}
+  client:
+    type: test
+    testData: "${  [1].([{'name': 'nozzleTime1', 'order':$}])  }"
 subscribeParams2: #parameters for subscribing to a cloud event
   source: cloudEvent
-  testData: "${  [1].([{'name': 'nozzleTime2', 'order':$}])  }"
   type: 'my-topic'
   filter$: function($e){ $e.name='nozzleTime' }
   to: ../${myWorkflow2$}
   parallelism: 2
   subscriberId: 'nozzleWork2'
+  client:
+    type: test
+    testData: "${  [1].([{'name': 'nozzleTime2', 'order':$}])  }"
 myWorkflow1$: |
   function($e){
       $e ~> $serial([step1, step2])

--- a/example/dumpster/workflow-fso.yaml
+++ b/example/dumpster/workflow-fso.yaml
@@ -8,9 +8,9 @@
 #   -H'appd-pid: ImZvb0BiYXIuY29tIg=='
 knowledgeStore:
   type: "my-topic"
-  data: "${ function(){  {'msg': 'hello', 'rando': $random()} } }"
   client:
     type: test
+    data: "${ function(){  {'msg': 'hello', 'rando': $random()} } }"
 # producer will be invoking "to" function for each consumed event
 subscribeParams: #parameters for subscribing to a cloud event
   source: cloudEvent

--- a/example/explicitAck.yaml
+++ b/example/explicitAck.yaml
@@ -1,0 +1,32 @@
+start: "${( $subscribe(subscribeParams); $publish(publishParams) )}"
+subscribeParams: #parameters for subscribing to a http request
+  to: ../${func}
+  type: "rebel"
+  parallelism: 2
+  source: "cloudEvent"
+  client:
+    explicitAck: true
+    acks: []
+    type: dispatcher
+publishParams:
+  type: "rebel"
+  source: "cloudEvent"
+  client:
+    type: test
+    data: [{type: "rebel", name: "luke"},{type: "rebel", name: "han"},{type: "rebel", name: "leia"}]
+func: "/${ function($data){( $console.log('got: ' & $data); $forked('/input',$data); )} }"
+input: null
+process: |
+  ${( 
+    $console.log('processing: ' & $$.input); 
+    $$.input != null ? ( 
+      $console.log('non-null input: ' & $$.input); 
+      $sleep($random()*1);
+      $joined('/results/-', $$.input);
+      $ack($$.input); 
+      $$.input) 
+    : 0 
+  )}
+results: []
+report: "${( $console.log('result added: ' & $$.results) )}"
+

--- a/example/inhabitants-with-delay.yaml
+++ b/example/inhabitants-with-delay.yaml
@@ -2,9 +2,9 @@
 produceParams:
   type: "residents"
   # fetch one page of planet data from the Star Wars API
-  data: ${[1].($fetch('https://swapi.tech/api/planets/?page=' & $string($)).json().results)}
   client:
     type: test
+    data: ${[1].($fetch('https://swapi.tech/api/planets/?page=' & $string($)).json().results)}
 subscribeResidents:
   source: cloudEvent
   type: /${ produceParams.type } # subscribe to the same topic as we are publishing to test events

--- a/example/inhabitants.yaml
+++ b/example/inhabitants.yaml
@@ -1,9 +1,9 @@
 # producer will be sending some test data
 produceParams:
   type: "my-topic"
-  data: ${[1..6].($fetch('https://swapi.tech/api/planets/?page=' & $string($)).json().results)}
   client:
     type: test
+    data: ${[1..6].($fetch('https://swapi.tech/api/planets/?page=' & $string($)).json().results)}
 subscribeResidents:
   source: cloudEvent
   type: /${ produceParams.type } # subscribe to the same topic as we are publishing to test events

--- a/example/joinResistance.yaml
+++ b/example/joinResistance.yaml
@@ -2,9 +2,9 @@ start: ${ (produceParams.data; $millis()) } #record start time, after test datas
 # producer will be sending some test data
 produceParams:
   type: "my-topic"
-  data: ${['luke', 'han', 'leia', 'R2-D2', 'Owen', 'Biggs', 'Obi-Wan', 'Anakin', 'Chewbacca', 'Wedge'].('https://swapi.tech/api/people/?search='&$)}
   client:
     type: test
+    data: ${['luke', 'han', 'leia', 'R2-D2', 'Owen', 'Biggs', 'Obi-Wan', 'Anakin', 'Chewbacca', 'Wedge'].('https://swapi.tech/api/people/?search='&$)}
 # the subscriber's 'to' function will be called on each received event
 subscribeParams: #parameters for subscribing to an event
   source: cloudEvent

--- a/example/joinResistanceBug.yaml
+++ b/example/joinResistanceBug.yaml
@@ -2,9 +2,9 @@ start: ${ (produceParams.data; $millis()) } #record start time, after test datas
 # producer will be sending some test data
 produceParams:
   type: "my-topic"
-  data: ${['luke', 'han', 'leia', 'R2-D2', 'Owen', 'Biggs', 'Obi-Wan', 'Anakin', 'Chewbacca', 'Wedge'].('https://swapi.tech/api/people/?name='&$)}
   client:
     type: test
+    data: ${['luke', 'han', 'leia', 'R2-D2', 'Owen', 'Biggs', 'Obi-Wan', 'Anakin', 'Chewbacca', 'Wedge'].('https://swapi.tech/api/people/?name='&$)}
 # the subscriber's 'to' function will be called on each received event
 subscribeParams: #parameters for subscribing to an event
   source: cloudEvent

--- a/example/joinResistanceFailing.yaml
+++ b/example/joinResistanceFailing.yaml
@@ -1,9 +1,9 @@
 # producer will be sending some test data
 produceParams:
   type: "my-topic"
-  data: ${['luke', 'han', 'leia', 'R2-D2', 'Owen', 'Biggs', 'Obi-Wan', 'Anakin', 'Chewbacca', 'Wedge']}
   client:
     type: test
+    data: ${['luke', 'han', 'leia', 'R2-D2', 'Owen', 'Biggs', 'Obi-Wan', 'Anakin', 'Chewbacca', 'Wedge']}
 # the subscriber's 'to' function will be called on each received event
 subscribeParams: #parameters for subscribing to an event
   source: cloudEvent

--- a/example/joinResistanceFast.yaml
+++ b/example/joinResistanceFast.yaml
@@ -2,9 +2,9 @@ start: ${ (produceParams.data; $millis()) } #record start time, after test datas
 # producer will be sending some test data
 produceParams:
   type: "my-topic"
-  data: ${['luke', 'han', 'leia', 'R2-D2', 'Owen', 'Biggs', 'Obi-Wan', 'Anakin', 'Chewbacca', 'Wedge'].('https://swapi.tech/api/people/?search='&$)}
   client:
     type: test
+    data: ${['luke', 'han', 'leia', 'R2-D2', 'Owen', 'Biggs', 'Obi-Wan', 'Anakin', 'Chewbacca', 'Wedge'].('https://swapi.tech/api/people/?search='&$)}
 # the subscriber's 'to' function will be called on each received event
 subscribeParams: #parameters for subscribing to an event
   source: cloudEvent

--- a/example/joinResistanceRecovery.yaml
+++ b/example/joinResistanceRecovery.yaml
@@ -2,9 +2,9 @@ start: ${ (produceParams.data; $millis()) } #record start time, after test datas
 # producer will be sending some test data
 produceParams:
   type: "rebelDispatch"
-  data: ['luke', 'han', 'leia']
   client:
     type: test # test client produces directly to the test subscriber dispatcher
+    data: ['luke', 'han', 'leia']
 # the subscriber's 'to' function will be called on each received event
 subscribeParams: #parameters for subscribing to an event
   source: cloudEvent

--- a/example/joinResistanceRecovery.yaml
+++ b/example/joinResistanceRecovery.yaml
@@ -13,9 +13,9 @@ subscribeParams: #parameters for subscribing to an event
   subscriberId: rebelArmy
   initialPosition: latest
   parallelism: 1
-  acks: []
   client:
     type: test
+    acks: []
 saveRebelWorkflow:
   function: | 
     /${ 

--- a/example/pubsub-pulsar.yaml
+++ b/example/pubsub-pulsar.yaml
@@ -1,9 +1,9 @@
 # producer will be sending some test data
 produceParams:
   type: "my-topic"
-  data: ['luke', 'han', 'leia']
   client:
     type: pulsar
+    data: ['luke', 'han', 'leia']
 # the subscriber's 'to' function will be called on each received event
 subscribeParams: #parameters for subscribing to an event
   source: cloudEvent

--- a/example/pubsub.yaml
+++ b/example/pubsub.yaml
@@ -1,9 +1,9 @@
 # producer will be sending some test data
 produceParams:
   type: "my-topic"
-  data: ['luke', 'han', 'leia']
   client:
     type: test
+    data: ['luke', 'han', 'leia']
 # the subscriber's 'to' function will be called on each received event
 subscribeParams: #parameters for subscribing to an event
   source: cloudEvent

--- a/example/pubsubDocker.yaml
+++ b/example/pubsubDocker.yaml
@@ -2,9 +2,9 @@
 interval$: ($subscribe(subscribeParams); $setInterval(function(){$publish(pubParams)}, 100))
 pubParams:
   type: /${ subscribeParams.type} #pub to same type we subscribe on
-  testData: [ {'msg':'hello'} ]
   client:
     type: test
+    testData: [ {'msg':'hello'} ]
 subscribeParams: #parameters for subscribing to a cloud event
   source: cloudEvent
   type: 'my-topic'

--- a/example/resistanceSnapshot.json
+++ b/example/resistanceSnapshot.json
@@ -3,13 +3,13 @@
     "start": "${ (produceParams.data; $millis()) }",
     "produceParams": {
       "type": "rebelDispatch",
-      "data": [
-        "luke",
-        "han",
-        "leia"
-      ],
       "client": {
-        "type": "test"
+        "type": "test",
+        "data": [
+          "luke",
+          "han",
+          "leia"
+        ]
       }
     },
     "subscribeParams": {
@@ -44,13 +44,13 @@
     "start": 1709667624225,
     "produceParams": {
       "type": "rebelDispatch",
-      "data": [
-        "luke",
-        "han",
-        "leia"
-      ],
       "client": {
-        "type": "test"
+        "type": "test",
+        "data": [
+          "luke",
+          "han",
+          "leia"
+        ]
       }
     },
     "subscribeParams": {

--- a/example/wf.yaml
+++ b/example/wf.yaml
@@ -2,12 +2,14 @@ start$: $subscribe(subscribeParams, {})
 name: nozzleWork
 subscribeParams: #parameters for subscribing to a cloud event
   source: cloudEvent
-  testData: "${  [1].([{'name': 'nozzleTime', 'order':$}])  }"
   type: 'my-topic'
   filter$: function($e){ $e.name='nozzleTime' }
   to: ../${myWorkflow$}
   parallelism: 2
   subscriberId: ../${name}
+  client:
+    type: test
+    testData: "${  [1].([{'name': 'nozzleTime', 'order':$}])  }"
 myWorkflow$: |
   function($e){
       $e ~> $serial([step1, step2])

--- a/example/wfDispatcher01.yaml
+++ b/example/wfDispatcher01.yaml
@@ -1,0 +1,31 @@
+start: "${( $subscribe(subscribeParams); $publish(publishParams) )}"
+subscribeParams: #parameters for subscribing to a http request
+  to: ../${func}
+  type: "rebel"
+  parallelism: 2
+  source: "cloudEvent"
+  explicitAck: true
+  client:
+    type: dispatcher
+publishParams:
+  type: "rebel"
+  source: "cloudEvent"
+  client:
+    type: test
+    data: [{type: "rebel", name: "luke"},{type: "rebel", name: "han"},{type: "rebel", name: "leia"}]
+func: "/${ function($data){( $console.log('got: ' & $data); $forked('/input',$data); )} }"
+input: null
+process: |
+  ${( 
+    $console.log('processing: ' & $$.input); 
+    $$.input != null ? ( 
+      $console.log('non-null input: ' & $$.input); 
+      $sleep($random()*1);
+      $joined('/results/-', $$.input);
+      $ack($$.input); 
+      $$.input) 
+    : 0 
+  )}
+results: []
+report: "${( $console.log('result added: ' & $$.results) )}"
+

--- a/example/wfDispatcher01.yaml
+++ b/example/wfDispatcher01.yaml
@@ -4,8 +4,9 @@ subscribeParams: #parameters for subscribing to a http request
   type: "rebel"
   parallelism: 2
   source: "cloudEvent"
-  explicitAck: true
   client:
+    explicitAck: true
+    acks: []
     type: dispatcher
 publishParams:
   type: "rebel"

--- a/example/wfDownloads.yaml
+++ b/example/wfDownloads.yaml
@@ -3,10 +3,10 @@ name: testConcurrentFetch
 subscribeParams: #parameters for subscribing to a cloud event
   to: ../${downloader$}
   parallelism: 5
-  testData: ${[1..10]}
   source: cloudEvent
   client:
     type: test
+    testData: ${[1..10]}
 
 downloader$: |
   function($noop){

--- a/example/wfHttp01.yaml
+++ b/example/wfHttp01.yaml
@@ -2,7 +2,9 @@ start$: $subscribe(subscribeParams)
 subscribeParams: #parameters for subscribing to a http request
   to: ../${myWebLambda$}
   parallelism: 2
-  source: http
+  source: cloudEvent
+  client:
+    type: http
 
 myWebLambda$: |
   function($con){

--- a/example/wfPerf01.yaml
+++ b/example/wfPerf01.yaml
@@ -1,7 +1,6 @@
 start$: $subscribe(subscribeParams)
 name: nozzleWork
 subscribeParams: #parameters for subscribing to a cloud event
-  testData: "${  [1..300].({'name': 'nozzleTime', 'order':$})  }"
   type: sys:cron
   filter$: function($e){ $e.name='nozzleTime' }
   to: ../${myWorkflow$}
@@ -9,6 +8,7 @@ subscribeParams: #parameters for subscribing to a cloud event
   source: cloudEvent
   client:
     type: test
+    testData: "${  [1..300].({'name': 'nozzleTime', 'order':$})  }"
 
 myWorkflow$: |
   function($e){

--- a/example/wfPersistent-with-state.yaml
+++ b/example/wfPersistent-with-state.yaml
@@ -3,12 +3,15 @@ name: nozzleWork
 subscribeParams: #parameters for subscribing to a cloud event
   source: cloudEvent
   # hardcore the messageId to make it easier to validate logs
-  testData: "${ [1].([{'messageId': '2023-10-15-1697394418495-o2d6', 'name': 'nozzleTime', 'order':$}]) }"
   type: 'my-topic'
   filter$: function($e){ $e.name='nozzleTime' }
   to: ../${myWorkflow$}
   parallelism: 2
   subscriberId: ../${name}
+  client:
+    type: test
+    testData: "${ [1].([{'messageId': '2023-10-15-1697394418495-o2d6', 'name': 'nozzleTime', 'order':$}]) }"
+
 myWorkflow$: |
   function($e){(
     $e ~> $serial(

--- a/example/wfPersistent.yaml
+++ b/example/wfPersistent.yaml
@@ -2,12 +2,14 @@ start$: $subscribe(subscribeParams)
 name: nozzleWork
 subscribeParams: #parameters for subscribing to a cloud event
   source: cloudEvent
-  data: "${ [1].([{'messageId': $id(), 'name': 'nozzleTime', 'order':$}]) }"
   type: 'my-topic'
   filter$: function($e){ $e.name='nozzleTime' }
   to: ../${myWorkflow$}
   parallelism: 2
   subscriberId: ../${name}
+  client:
+    type: test
+    data: "${ [1].([{'messageId': $id(), 'name': 'nozzleTime', 'order':$}]) }"
 myWorkflow$: |
   function($e){(
     $e ~> $serial(

--- a/example/wfPersistent2.yaml
+++ b/example/wfPersistent2.yaml
@@ -2,12 +2,14 @@ start$: $subscribe(subscribeParams)
 name: nozzleWork
 subscribeParams: #parameters for subscribing to a cloud event
   source: cloudEvent
-  testData: "${ [1].([{'messageId': $id(), 'name': 'nozzleTime', 'order':$}]) }"
   type: 'my-topic'
   filter$: function($e){ $e.name='nozzleTime' }
   to: ../${myWorkflow$}
   parallelism: 2
   subscriberId: ../${name}
+  client:
+    type: test
+    testData: "${ [1].([{'messageId': $id(), 'name': 'nozzleTime', 'order':$}]) }"
 myWorkflow$: |
   function($e){(
     $e ~> $serial(

--- a/src/test/StatedWorkflow.test.js
+++ b/src/test/StatedWorkflow.test.js
@@ -1113,7 +1113,7 @@ test("workflow snapshot and restore", async () => {
                 expect(snapshot.output.rebels.length).toEqual(1);
                 expect(StatedREPL.stringify(snapshot.output.rebels)).toEqual(StatedREPL.stringify([
                     {"name": "Luke Skywalker", "url": "https://www.swapi.tech/api/planets/1"}]));
-                expect(StatedREPL.stringify(snapshot.output.subscribeParams.acks)).toEqual(StatedREPL.stringify(["luke"]));
+                expect(StatedREPL.stringify(snapshot.output.subscribeParams.client.acks)).toEqual(StatedREPL.stringify(["luke"]));
                 // the output should also have a log for 'han' invocationId complete for fetchRebel
                 expect (snapshot.output.fetchRebel.log.han.end).toBeDefined();
 
@@ -1150,7 +1150,7 @@ test("workflow snapshot and restore", async () => {
         {"name": "Leia Organa", "url": "https://www.swapi.tech/api/planets/2"}
     ]));
     // Expect that each rebel data was acknowledged once.
-    expect(StatedREPL.stringify(tp.output.subscribeParams.acks)).toEqual(StatedREPL.stringify(["luke", "han", "leia"]));
+    expect(StatedREPL.stringify(tp.output.subscribeParams.client.acks)).toEqual(StatedREPL.stringify(["luke", "han", "leia"]));
     // validate that fetchRebel step was completed exactly once. On the first try, it leaves a log for 'han' with start
     // and end. On the second try the workflow starts from 'han', which hasn't been acknowledged, but has a complete
     // fetchRebel log and will be skipped.

--- a/src/workflow/StatedWorkflow.js
+++ b/src/workflow/StatedWorkflow.js
@@ -148,8 +148,8 @@ export class StatedWorkflow {
                 dispatcher.dataAckCallbacks.delete(data);
             }
             if (dispatcher.active > 0) dispatcher.active--;
-            if (dispatcher.preQueue.length > 0) {
-                const next = dispatcher.preQueue.shift();
+            if (dispatcher.waitQueue.length > 0) {
+                const next = dispatcher.waitQueue.shift();
                 next();
             }
         }

--- a/src/workflow/StatedWorkflow.js
+++ b/src/workflow/StatedWorkflow.js
@@ -525,6 +525,43 @@ export class StatedWorkflow {
         });
     }
 
+    // subscribeTest is a test function that is used to test the workflow without a real subscription
+    //
+    // it can operate in two modes
+    // 1. If client.testData is provided, it will be added to the dispatcher and awaited processing
+    // 2. If test publisher is provided, it will be used to publish data to the dispatcher
+    // additional configuration:
+    // - If client.acks is provided, it will be used to acknowledge the data
+    async subscribeTest(subscriptionParams, subscribeParamsJsonPointer) {
+        const {client:clientParams = {}} = subscriptionParams;
+        let testDataAckFunctionGenerator;
+        if (Array.isArray(clientParams.acks)) {
+            testDataAckFunctionGenerator = (data) => {
+                return (async () => {
+                    if (Array.isArray(clientParams.acks)) {
+                        console.debug(`acknowledging data: ${StatedREPL.stringify(data)}`);
+                        await this.templateProcessor.setData(subscribeParamsJsonPointer + '/client/acks/-',data);
+                    }
+                }).bind(this);
+            };
+        }
+
+        this.logger.debug(`No 'real' subscription created because client.type='test' set for subscription params ${StatedREPL.stringify(subscriptionParams)}`);
+
+        const dispatcher = this.workflowDispatcher.getDispatcher(subscriptionParams)
+        if (clientParams.explicitAck) {
+            this.workflowDispatcher.explicitAck = true; // ensure that the dispatcher knows that we are using explicit acks
+        }
+        dispatcher.testDataAckFunctionGenerator = testDataAckFunctionGenerator;
+
+        // testData may contain some canned data to be used without a publisher.
+        if (clientParams.type === "test" && clientParams.testData !== undefined) {
+            this.logger.debug(`No 'real' subscription created because testData provided for subscription params ${StatedREPL.stringify(subscriptionParams)}`);
+            await dispatcher.addBatch(clientParams.testData);
+            await dispatcher.drainBatch(); // in test mode we wanna actually wait for all the test events to process
+        }
+    }
+
     async subscribeCloudEvent(subscriptionParams, subscribeParamsJsonPointer) {
         const {client:clientParams={type:'test'}, to} = subscriptionParams;
         //to-do fixme do validation of subscriptionParams
@@ -536,37 +573,8 @@ export class StatedWorkflow {
 
         const {type:clientType} = clientParams;
 
-        // testData may contain some canned data to be used without a publisher.
-        if (clientParams.type === "test" && clientParams.testData !== undefined) {
-            this.logger.debug(`No 'real' subscription created because testData provided for subscription params ${StatedREPL.stringify(subscriptionParams)}`);
-            const testDataAckFunctionGenerator = ((data) => {
-                return async () => {
-                    // we check if subscriptionParams.acks is an array to enable acks. If the array is missing, acks
-                    // are not enabled and we do not need to do anything.
-                    if (clientParams !== undefined && Array.isArray(clientParams.acks)) {
-                        await this.templateProcessor.setData(subscribeParamsJsonPointer + '/client/acks/-',data);
-                    }
-                }
-            }).bind(this);
-            const dispatcher = this.workflowDispatcher.getDispatcher(subscriptionParams, testDataAckFunctionGenerator);
-
-            await dispatcher.addBatch(clientParams.testData);
-            await dispatcher.drainBatch(); // in test mode we wanna actually wait for all the test events to process
-            return;
-        }
-
         if(clientParams.type === "test"){
-            this.logger.debug(`No 'real' subscription created because client.type='test' set for subscription params ${StatedREPL.stringify(subscriptionParams)}`);
-            const testDataAckFunctionGenerator = (data) => {
-                return (async () => {
-                    if (Array.isArray(clientParams.acks)) {
-                        console.debug(`acknowledging data: ${StatedREPL.stringify(data)}`);
-                        await this.templateProcessor.setData(subscribeParamsJsonPointer + '/client/acks/-',data);
-                    }
-                }).bind(this);
-            };
-            // validates that we have a dispatcher created for this subscriptionParams.
-            this.workflowDispatcher.getDispatcher(subscriptionParams, testDataAckFunctionGenerator);
+            await this.subscribeTest(subscriptionParams, subscribeParamsJsonPointer);
         } else if (clientType === 'dispatcher') {
             this.logger.debug(`No 'real' subscription created because client.type='dispatcher' set for subscription params ${StatedREPL.stringify(subscriptionParams)}`);
             this.workflowDispatcher.getDispatcher(subscriptionParams);

--- a/src/workflow/StatedWorkflow.js
+++ b/src/workflow/StatedWorkflow.js
@@ -142,11 +142,15 @@ export class StatedWorkflow {
         const dispatcherType = this.workflowDispatcher.dispatchers.get(data.type);
         for (let t of dispatcherType) {
             const dispatcher = this.workflowDispatcher.dispatcherObjects.get(t);
-            const ackCallback = dispatcher.dataAckCallbacks.get(data);
+            const ackCallback = dispatcher.dataAckCallbacks?.get(data);
             if (ackCallback) {
                 ackCallback(data);
                 dispatcher.dataAckCallbacks.delete(data);
-                if (dispatcher.active > 0) dispatcher.active--;
+            }
+            if (dispatcher.active > 0) dispatcher.active--;
+            if (dispatcher.preQueue.length > 0) {
+                const next = dispatcher.preQueue.shift();
+                next();
             }
         }
 

--- a/src/workflow/StatedWorkflow.js
+++ b/src/workflow/StatedWorkflow.js
@@ -90,7 +90,7 @@ export class StatedWorkflow {
         this.templateProcessor.functionGenerators.set("parallel", this.parallelGenerator.bind(this));
         this.templateProcessor.functionGenerators.set("recoverStep", this.recoverStepGenerator.bind(this));
         this.templateProcessor.functionGenerators.set("subscribe", this.subscribeGenerator.bind(this));
-        this.templateProcessor.logLevel = logLevel.DEBUG; //log level must be ERROR by default. Do not commit code that sets this to DEBUG as a default
+        this.templateProcessor.logLevel = logLevel.ERROR; //log level must be ERROR by default. Do not commit code that sets this to DEBUG as a default
         this.hasChanged = true;
         this.changeListener = ()=>{this.hasChanged=true};
         this.snapshotInterval = null;
@@ -139,17 +139,16 @@ export class StatedWorkflow {
     //
     async ack(data) {
         console.log(`acknowledging data: ${StatedREPL.stringify(data)}`);
-/*
-        // const dispatcherType = this.workflowDispatcher.dispatchers.get(data.type);
-        // for (let t of dispatcherType) {
-        //     const dispatcher = this.workflowDispatcher.dispatcherObjects.get(t);
-        //     const ackCallback = dispatcher.dataAckCallbacks.get(data);
-        //     if (ackCallback) {
-        //         ackCallback(data);
-        //         dispatcher.dataAckCallbacks.delete(data);
-        //     }
-        // }
-*/
+        const dispatcherType = this.workflowDispatcher.dispatchers.get(data.type);
+        for (let t of dispatcherType) {
+            const dispatcher = this.workflowDispatcher.dispatcherObjects.get(t);
+            const ackCallback = dispatcher.dataAckCallbacks.get(data);
+            if (ackCallback) {
+                ackCallback(data);
+                dispatcher.dataAckCallbacks.delete(data);
+                if (dispatcher.active > 0) dispatcher.active--;
+            }
+        }
 
     }
 

--- a/src/workflow/StatedWorkflow.js
+++ b/src/workflow/StatedWorkflow.js
@@ -553,14 +553,15 @@ export class StatedWorkflow {
         // clientType test means that the data will be sent directly from publish function to the dispatcher
         if(clientParams.type === "test") {
             this.logger.debug(`No 'real' subscription created because client.type='test' set for subscription params ${StatedREPL.stringify(subscriptionParams)}`);
-            const testDataAckFunctionGenerator = (data) => {
-                return async () => {
+            const testDataAckFunctionGenerator = ((data) => {
+                return (async () => {
                     if (Array.isArray(clientParams.acks)) {
                         console.debug(`acknowledging data: ${StatedREPL.stringify(data)}`);
                         await this.templateProcessor.setData(subscribeParamsJsonPointer + '/client/acks/-', data);
+                        console.log('success in setData')
                     }
-                }
-            };
+                }).bind(this);
+            }).bind(this);
             // validates that we have a dispatcher created for this subscriptionParams.
             this.workflowDispatcher.getDispatcher(subscriptionParams, testDataAckFunctionGenerator);
         } else if (clientType === 'dispatcher') {

--- a/src/workflow/StatedWorkflow.js
+++ b/src/workflow/StatedWorkflow.js
@@ -90,7 +90,7 @@ export class StatedWorkflow {
         this.templateProcessor.functionGenerators.set("parallel", this.parallelGenerator.bind(this));
         this.templateProcessor.functionGenerators.set("recoverStep", this.recoverStepGenerator.bind(this));
         this.templateProcessor.functionGenerators.set("subscribe", this.subscribeGenerator.bind(this));
-        this.templateProcessor.logLevel = logLevel.ERROR; //log level must be ERROR by default. Do not commit code that sets this to DEBUG as a default
+        this.templateProcessor.logLevel = logLevel.DEBUG; //log level must be ERROR by default. Do not commit code that sets this to DEBUG as a default
         this.hasChanged = true;
         this.changeListener = ()=>{this.hasChanged=true};
         this.snapshotInterval = null;
@@ -228,7 +228,7 @@ export class StatedWorkflow {
 
         if (clientParams.type === 'test' && clientParams.data !== undefined) {
             this.logger.debug(`test client provided, will not publish to 'real' message broker for publish parameters ${StatedREPL.stringify(params)}`);
-            await this.workflowDispatcher.addBatchToAllSubscribers(type, clientParams.data);
+            await this.workflowDispatcher.addBatchToAllSubscribers(type, clientParams);
             return "done";
         }
 
@@ -558,7 +558,7 @@ export class StatedWorkflow {
                     if (Array.isArray(clientParams.acks)) {
                         console.debug(`acknowledging data: ${StatedREPL.stringify(data)}`);
                         await this.templateProcessor.setData(subscribeParamsJsonPointer + '/client/acks/-', data);
-                        console.log('success in setData')
+                        console.log(`template output of the json pointer ${subscribeParamsJsonPointer + '/client/acks'} is ${StatedREPL.stringify(this.templateProcessor.out(subscribeParamsJsonPointer + '/client/acks'))}`)
                     }
                 }).bind(this);
             }).bind(this);

--- a/src/workflow/WorkflowDispatcher.js
+++ b/src/workflow/WorkflowDispatcher.js
@@ -208,7 +208,7 @@ export class WorkflowDispatcher {
         if (Array.isArray(testData)) {
             this.batchCount += testData.length;
             for(let i=0;i<testData.length;i++){
-                if (Array.isArray(this.subscribeParams.acks) && this.subscribeParams.acks.includes(testData[i])) {
+                if (this.subscribeParams.client !== undefined && Array.isArray(this.subscribeParams.client.acks) && this.subscribeParams.client.acks.includes(testData[i])) {
                     console.debug(`Skipping already acknowledged test data: ${testData[i]}`);
                 } else {
                     await this.addToQueue(testData[i]);

--- a/src/workflow/WorkflowDispatcher.js
+++ b/src/workflow/WorkflowDispatcher.js
@@ -64,8 +64,20 @@ export class WorkflowDispatcher {
         return this.dispatcherObjects.get(key);
     }
 
+    async addBatchToAllSubscribers(type, testData) {
+        const keysSet = this.dispatchers.get(type);
+        if (keysSet) {
+            for (let key of keysSet) {
+                const dispatcher = this.dispatcherObjects.get(key);
+                dispatcher.addBatch(testData); // You can pass the actual data you want to dispatch here
+            }
+        } else {
+            console.log(`No subscribers found for type ${type}`);
+        }
+    }
+    /**/
     // this function is only used from test publisher
-    async addBatchToAllSubscribers(type, clientParams = {}, ackFunc) {
+    async addBatchToAllSubscribersWithAck(type, clientParams = {}, ackFunc) {
         const promises = [];
         for (let data of clientParams.data) {
             type = data.type || type;

--- a/src/workflow/WorkflowDispatcher.js
+++ b/src/workflow/WorkflowDispatcher.js
@@ -72,19 +72,6 @@ export class WorkflowDispatcher {
             if (keysSet) {
                 for (let key of keysSet) {
                     const dispatcher = this.dispatcherObjects.get(key);
-
-                    let resolve = () => {};
-                    promises.push(new Promise((_resolve) => {
-                        resolve = _resolve;
-                        resolve();
-                    }));
-
-                    if (ackFunc === undefined) {
-                        ackFunc = async (data) => {
-                            console.log(`Acknowledging data of type ${data.type}, data: ${StatedREPL.stringify(data)}`);
-                            resolve();
-                        }
-                    }
                     dispatcher.addToQueue(data, ackFunc);
 
                 }
@@ -240,9 +227,6 @@ export class WorkflowDispatcher {
                 if (this.subscribeParams.client !== undefined && Array.isArray(this.subscribeParams.client.acks) && this.subscribeParams.client.acks.includes(testData[i])) {
                     console.debug(`Skipping already acknowledged test data: ${testData[i]}`);
                 } else {
-                    const ack = async (data) => {
-                        console.log(`Acknowledging data of type ${data.type}, data: ${StatedREPL.stringify(data)}`);
-                    }
                     await this.addToQueue(testData[i]);
                 }
             }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2952,9 +2952,9 @@ stack-utils@^2.0.3:
     escape-string-regexp "^2.0.0"
 
 stated-js@^0.1.20:
-  version "0.1.20"
-  resolved "https://registry.npmjs.org/stated-js/-/stated-js-0.1.20.tgz"
-  integrity sha512-jN2c3mKxqiEKr0h/TSqwfWQs0nL8AOZUDzCZt7Awo88j68EeAUBXDYr3xPA7UHIatV0UV5+J0TmxUsEbFccXJw==
+  version "0.1.23"
+  resolved "https://registry.yarnpkg.com/stated-js/-/stated-js-0.1.23.tgz#b2526a7bb1cb6cbf59a6bbb0da8dbdbfe71542ab"
+  integrity sha512-r8ntZm4hHY0AVhlapAVAi+eqGJZM8oDTtrR29n9FEslbdFO4gFCyeIPWNe6H3/TcH6KNmqUBFiXu4wo/AEZlng==
   dependencies:
     chalk "^5.3.0"
     flatbuffers "^23.5.26"


### PR DESCRIPTION
## Description

- add `explicitAcks` configuration, to make sure that we support this mode when `ack()` should be invoked from the workflow code. 
- Move all `client` config to the `client` section, docs++
```yaml
subscriptionParams:
  client:
    type: test
    acks: []
    explicitAcks: true
```
- refactoring and cleanups

## Type of Change

- [ ] Bug Fix
- [X] New Feature
- [ ] Breaking Change
- [X] Refactor
- [X] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
